### PR TITLE
build: add `react-grid-layout` as required dep to ensure @vektor-finance/types is imported correctly

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -32,8 +32,10 @@
     "pack": "npm pack",
     "pre-commit": "lint-staged"
   },
+  "dependencies": {
+    "@types/react-grid-layout": "1.3.5"
+  },
   "devDependencies": {
-    "@types/react-grid-layout": "1.3.5",
     "@vektor-finance/eslint-config-sdk": "^0.42.2",
     "@vektor-finance/utils": "^0.42.2",
     "lint-staged": "12.4.1",


### PR DESCRIPTION
### Motivation

Move `@types/react-grid-layout` to `dependencies` so that it's included - otherwise when you import `@vektor-finance/types` it will fail to build. 

In future this dependency should be removed.

### Solution

build: add react-grid-layout as required dep

### Open questions

<!--
(optional) Any open questions or feedback on design desired?
-->

### Checklist

- [ ] I've confirmed that my PR passes all linting checks
- [ ] I've included test cases
- [ ] I've updated the documentation
- [ ] I've add `reviewers` where systems they are responsible for is impacted
